### PR TITLE
iBus package is lacking

### DIFF
--- a/bm/Language-Japanese_Input.bm
+++ b/bm/Language-Japanese_Input.bm
@@ -16,6 +16,7 @@ FLL_PACKAGES=(
         ibus-mozc
         ibus-qt4
         ibus-gtk3
+        ibus-gtk
         python-appindicator
         fonts-vlgothic
         manpages-ja


### PR DESCRIPTION
Because a package necessary for Japanese input is short, a problem occurs,
It is necessary to reflect this.

http://forum.mepiscommunity.org/viewtopic.php?t=36518
