### PR TITLE
remove mozilla-acroread from bm file

### DIFF
--- a/bm/Office-Adobe_Reader.bm
+++ b/bm/Office-Adobe_Reader.bm
@@ -16,8 +16,7 @@ FLL_PACKAGE_DEPMODS=(
 )
 
 FLL_PACKAGES=(
-	acroread 
-        mozilla-acroread 
+	acroread
 
 )
 


### PR DESCRIPTION
mozilla-acroread is not longer a package at deb-multimedia